### PR TITLE
fix: detail urls on pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 .mason/
 
+build/
+
 node_modules/
 
 **/.dart_tool/

--- a/packages/blog_repository/lib/src/blog_repository.dart
+++ b/packages/blog_repository/lib/src/blog_repository.dart
@@ -27,6 +27,16 @@ class BlogRepository {
   final ButterCmsClient _cmsClient;
   final TemplateEngine _templateEngine;
 
+  final _defaultMetaContext = {
+    'metaTitle': defaultMetaTitle,
+    'metaDescription': defaultMetaDescription,
+  };
+
+  final _globalContext = {
+    'baseBlogsUrl': Platform.environment['BASE_BLOGS_URL'] ?? '',
+    'year': currentYear,
+  };
+
   /// Fetches a detailed blog post by [slug] and generates HTML for the client.
   Future<RenderedContent> getBlogDetailHtml(String slug) async {
     try {
@@ -57,7 +67,7 @@ class BlogRepository {
           'metaTitle': blogDetail.seoTitle,
           'metaDescription': blogDetail.metaDescription,
           'metaImageUrl': blogDetail.featuredImage,
-          'year': currentYear,
+          ..._globalContext,
         },
       );
       return (200, html);
@@ -111,16 +121,15 @@ class BlogRepository {
               filePath: 'blog_overview_page.html',
               context: {
                 'posts': posts,
-                'metaTitle': defaultMetaTitle,
-                'metaDescription': defaultMetaDescription,
-                'year': currentYear,
-                'baseBlogsUrl': Platform.environment['BASE_BLOGS_URL'] ?? '',
+                ..._defaultMetaContext,
+                ..._globalContext,
               },
             )
           : await _templateEngine.render(
               filePath: 'blog_preview_list.html',
               context: {
                 'posts': posts,
+                'baseBlogsUrl': Platform.environment['BASE_BLOGS_URL'] ?? '',
               },
             );
 
@@ -144,9 +153,8 @@ class BlogRepository {
       filePath: 'error_page.html',
       context: {
         'message': message,
-        'metaTitle': defaultMetaTitle,
-        'metaDescription': defaultMetaDescription,
-        'year': currentYear,
+        ..._defaultMetaContext,
+        ..._globalContext,
       },
     );
     return (statusCode, errorHtml);


### PR DESCRIPTION
- Closes #20 
- Ensures proper url is passed via rendering context on every call to overview page
- Refactors commonly used metadata and context properties in `blog_repository` to be DRYer
- .gitignores build dir