### PR TITLE
feat: default meta image

### DIFF
--- a/packages/blog_models/lib/src/data_models/blog_summary.dart
+++ b/packages/blog_models/lib/src/data_models/blog_summary.dart
@@ -29,7 +29,7 @@ class BlogSummary extends Equatable {
   final String title;
 
   /// Featured image of the blog post.
-  final String featuredImage;
+  final String? featuredImage;
 
   @override
   List<Object?> get props => [slug, title, featuredImage];

--- a/packages/blog_models/lib/src/data_models/blog_summary.g.dart
+++ b/packages/blog_models/lib/src/data_models/blog_summary.g.dart
@@ -9,7 +9,7 @@ part of 'blog_summary.dart';
 BlogSummary _$BlogSummaryFromJson(Map<String, dynamic> json) => BlogSummary(
       slug: json['slug'] as String,
       title: json['title'] as String,
-      featuredImage: json['featured_image'] as String,
+      featuredImage: json['featured_image'] as String?,
     );
 
 Map<String, dynamic> _$BlogSummaryToJson(BlogSummary instance) =>

--- a/packages/blog_models/lib/src/data_models/blogs_meta.g.dart
+++ b/packages/blog_models/lib/src/data_models/blogs_meta.g.dart
@@ -7,9 +7,9 @@ part of 'blogs_meta.dart';
 // **************************************************************************
 
 BlogsMeta _$BlogsMetaFromJson(Map<String, dynamic> json) => BlogsMeta(
-      count: json['count'] as int,
-      nextPage: json['next_page'] as int?,
-      previousPage: json['previous_page'] as int?,
+      count: (json['count'] as num).toInt(),
+      nextPage: (json['next_page'] as num?)?.toInt(),
+      previousPage: (json['previous_page'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$BlogsMetaToJson(BlogsMeta instance) => <String, dynamic>{

--- a/packages/blog_repository/lib/src/blog_repository.dart
+++ b/packages/blog_repository/lib/src/blog_repository.dart
@@ -66,7 +66,7 @@ class BlogRepository {
           'featuredImage': blogDetail.featuredImage,
           'metaTitle': blogDetail.seoTitle,
           'metaDescription': blogDetail.metaDescription,
-          'metaImageUrl': blogDetail.featuredImage,
+          'metaImageUrl': blogDetail.featuredImage ?? defaultMetaImageUrl,
           ..._globalContext,
         },
       );

--- a/packages/blog_repository/lib/src/constants.dart
+++ b/packages/blog_repository/lib/src/constants.dart
@@ -9,3 +9,7 @@ const defaultMetaDescription = 'Exploring my post-academic experiences '
 
 /// The current year, used in the footer of the blog site.
 final currentYear = DateTime.now().year;
+
+/// URL to the default meta image that will be displayed when sharing
+/// to Facebook and Twitter.
+const defaultMetaImageUrl = 'https://cdn.buttercms.com/k0VqhfH2Tqaem5CBGcAA';


### PR DESCRIPTION
- Adding a default meta image URL from Butter CMS so that something decent appears when sharing on FB
- Adding a nullable to `BlogSummary` to fix a serialization error when there is no featured img (unrelated but found while implementing the default image)