### PR TITLE
chore: deleting old claude file

### DIFF
--- a/blog_update_handler/CLAUDE.md
+++ b/blog_update_handler/CLAUDE.md
@@ -1,7 +1,0 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this package.
-
-# Blog Update Handler
-
-The purpose of this package is to fetch new blog posts from `butter_cms_client` and publish them via the `newsletter_client`. 


### PR DESCRIPTION
Removing `CLAUDE.md` in `blog_update_handler` as it is no longer necessary (and shouldn't have been committed at first anyway)