### PR TITLE
fix: redirecting routes with ending slashes

### DIFF
--- a/routes/_middleware.dart
+++ b/routes/_middleware.dart
@@ -6,12 +6,13 @@ import 'package:blog_repository/blog_repository.dart';
 import 'package:butter_cms_client/butter_cms_client.dart';
 import 'package:captcha_client/captcha_client.dart';
 import 'package:dart_frog/dart_frog.dart';
-import 'package:http/http.dart';
+import 'package:http/http.dart' hide Response;
 import 'package:subscriptions_repository/subscriptions_repository.dart';
 import 'package:template_engine/template_engine.dart';
 
 Handler middleware(Handler handler) {
   return handler
+      .use(_trailingSlashRedirect)
       .use(requestLogger())
       .use(
         provider<BlogRepository>(
@@ -88,4 +89,24 @@ Handler middleware(Handler handler) {
   ).use(
     provider<ApiClient>((_) => ApiClient(client: Client())),
   );
+}
+
+/// Redirects any request whose path ends in a trailing `/` (except the root)
+/// to the equivalent path without the trailing slash, preserving the query
+/// string. E.g. `/blogs/{slug}/` -> `/blogs/{slug}`.
+Handler _trailingSlashRedirect(Handler handler) {
+  return (context) {
+    final uri = context.request.uri;
+    final path = uri.path;
+
+    if (path.length > 1 && path.endsWith('/')) {
+      final normalized = path.substring(0, path.length - 1);
+      return Response(
+        statusCode: 301,
+        headers: {'location': uri.replace(path: normalized).toString()},
+      );
+    }
+
+    return handler(context);
+  };
 }


### PR DESCRIPTION
Adding a universal redirect so that `route/name/` goes to `route/name`